### PR TITLE
fix #13 remove Twig.logic.type.include from render tag extension definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frctl/twig",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frctl/twig",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.4",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {

--- a/src/tags/render.js
+++ b/src/tags/render.js
@@ -11,7 +11,7 @@ const path = require('path');
 module.exports = function (fractal) {
     return function (Twig) {
         return {
-            type: Twig.logic.type.include,
+            type: 'rendertag',
             regex: /^render\s+(.+?)\s*(?:with\s+([\S\s]+?))?\s*$/,
             next: [],
             open: true,


### PR DESCRIPTION
fixes #13
it seems that using twig's internal types overrides the language tags