### PR TITLE
Fix "Cannot read property 'request' of undefined"

### DIFF
--- a/src/filters/path.js
+++ b/src/filters/path.js
@@ -7,10 +7,13 @@ module.exports = function(fractal) {
 
     return function(path) {
 
-        let env = this.context._env;
-        let request = env.request || this.context._request;
+        if(!this.context._env || this.context._env.server) {
+            return path;
+        } else {
+            const request = this.context._env.request || this.context._request;
+            return utils.relUrlPath(path, _.get(request, 'path', '/'), fractal.web.get('builder.urls'));
+        }
 
-        return (! env || env.server) ? path : utils.relUrlPath(path, _.get(request, 'path', '/'), fractal.web.get('builder.urls'));
     }
 
 };


### PR DESCRIPTION
A "render" template like e.g.:

```twig
{% render "@utility-nav" %}
{% render "@header" %}
```

triggers the following error:

![000016](https://user-images.githubusercontent.com/8310677/53111318-25810380-353d-11e9-860a-e65d27e1fbd8.png)

The reason being that `let request = env.request || this.context._request;` is executed before the check of `env`.