### PR TITLE
Allow passing twig.js namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ const twigAdapter = require('@frctl/twig')({
     // default is false
     strict_variables: true,
 
+    // define Twig namespaces, see https://github.com/twigjs/twig.js/wiki#namespaces
+    // this may break some fractal functionality, like including components via their handles and the render tag
+    namespaces: {
+        'Components': './components'
+    },
+
     // register custom filters
     filters: {
         // usage: {{ label|capitalize }}

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -151,7 +151,8 @@ class TwigAdapter extends Fractal.Adapter {
                     async: false,
                     rethrow: true,
                     name: meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath,
-                    precompiled: str
+                    precompiled: str,
+                    namespaces: self._config.namespaces || {}
                 });
                 resolve(template.render(context));
             } catch (e) {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -154,7 +154,7 @@ class TwigAdapter extends Fractal.Adapter {
                     precompiled: str,
                     base: self._config.base,
                     strict_variables: self._config.strict_variables,
-                    namespaces: self._config.namespaces || {}
+                    namespaces: self._config.namespaces
                 });
                 resolve(template.render(context));
             } catch (e) {
@@ -179,7 +179,8 @@ module.exports = function(config) {
         handlePrefix: '@',
         importContext: false,
         base: null,
-        strict_variables: false
+        strict_variables: false,
+        namespaces: {}
     });
 
     return {


### PR DESCRIPTION
https://github.com/justjohn/twig.js/wiki#user-content-namespaces

Allows specifying e.g. 

```js
const twigAdapter = require('@frctl/twig')({
  namespaces: {
    'Components': ''
  }
});
```

to then use:

```twig
{% include "@Components/03-common/bottom-up/bottom-up.twig" %}
```

I needed this because I'm using `@Components` in my backend to reference to the components frontend folder.