### PR TITLE
Early return path for server

### DIFF
--- a/src/filters/path.js
+++ b/src/filters/path.js
@@ -6,11 +6,13 @@ const utils = require('@frctl/fractal').utils;
 module.exports = function(fractal) {
 
     return function(path) {
-
         let env = this.context._env;
-        let request = env.request || this.context._request;
+        if (!env || env.server) {
+            return path;
+        }
 
-        return (! env || env.server) ? path : utils.relUrlPath(path, _.get(request, 'path', '/'), fractal.web.get('builder.urls'));
+        let request = env.request || this.context._request;
+        return utils.relUrlPath(path, _.get(request, 'path', '/'), fractal.web.get('builder.urls'));
     }
 
 };


### PR DESCRIPTION
## Problem

An error is thrown whenever when using the path filter within an embedded component.

## Context

* We can assume the file is always relative to the root because the server always runs on `http://localhost:${port}` (see [@frctl/fractal/src/web/server.js](https://github.com/frctl/fractal/blob/develop/src/web/server.js#L78))
* resolves #20. 

## Solution

Return the path early when a server is detected.

*Inspired by https://github.com/frctl/handlebars/blob/develop/src/helpers/path.js*



