### PR TITLE
Expose twigjs base path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ const twigAdapter = require('@frctl/twig')({
     // this will change your includes to {% include '%button' %}
     // default is '@'
     handlePrefix: '%',
+    
+    // set a base path for twigjs
+    // Setting base to '/' will make sure all resolved render paths
+    // start at the defined components dir, instead of being relative.
+    // default is null
+    base: '/',
 
     // register custom filters
     filters: {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -151,7 +151,8 @@ class TwigAdapter extends Fractal.Adapter {
                     async: false,
                     rethrow: true,
                     name: meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath,
-                    precompiled: str
+                    precompiled: str,
+                    base: self._config.base
                 });
                 resolve(template.render(context));
             } catch (e) {
@@ -174,7 +175,8 @@ module.exports = function(config) {
     config = _.defaults(config || {}, {
         pristine: false,
         handlePrefix: '@',
-        importContext: false
+        importContext: false,
+        base: null
     });
 
     return {


### PR DESCRIPTION
**Allow configuring of base path in twigjs to make it behave like PHP Twig.**

Given this directory structure:

```
├── components
│   └── icons
│   │   ├── icon.twig
│   └── buttons
│   │   ├── button.twig
│   └── widgets
│   │   ├── card.twig
```

And these templates:

```
{# widgets/card.twig #}
<div>
    <h2>Card Title</h2>
    <div>
        {% include 'widgets/button.twig' %}
    </div>
</div>
```

```
{# buttons/button.twig #}
<button type="button">
    <span>Button Label</span>
    {% include 'icons/icon.twig' %}
</button>
```

```
{# icons/icon.twig #}
<svg viewBox="0 0 10 10" width="10" height="10">
    <rect x="0" y="0" width="10" height="10" fill="#000000"></rect>
</svg>
```

Fractal will fail to render the Card component with this error:

`Error: Template widgets/icons/icon.twig not found`

because down the line twigjs resolves the path as relative to the template instead of from the root of component directory. Adding the `base` option to the twigjs render function fixes this, but the Fractal Twig adapter does not expose that option. This PR adds that.