### PR TITLE
Support data references in render tag.

### DIFF
--- a/src/tags/render.js
+++ b/src/tags/render.js
@@ -53,7 +53,7 @@ module.exports = function (fractal) {
                     throw new Error(`Could not render component '${handle}' - component not found.`);
                 }
 
-                let innerContext = entity.isComponent ? entity.variants().default().context : entity.context;
+                let innerContext = entity.isComponent ? entity.variants().default().getContext() : entity.getContext();
 
                 if (token.contextStack !== undefined) {
                     _.assign(innerContext, Twig.expression.parse.apply(this, [token.contextStack, context]));


### PR DESCRIPTION
Use `getContext()` to fetch `innerContext` in order to trigger the data reference handling.