### PR TITLE
add support for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,29 @@ fractal.components.engine(twigAdapter);
 fractal.components.set('ext', '.twig');
 ```
 
+## Using Twig for docs
+
+To use Twig for docs, set the docs engine to `@frctl/twig`:
+```
+fractal.docs.engine(twigAdapter);
+```
+
+However, due to the way this adapter currently extends Twig, it is necessary to *set the docs engine before setting the components engine*.
+
+```
+/*
+ * Require the Twig adapter
+ */
+const twigAdapter = require('@frctl/twig')();
+
+// first set docs engine
+fractal.docs.engine(twigAdapter);
+
+// then set components engine
+fractal.components.engine(twigAdapter);
+```
+
+
 ## Extending with a custom config
 ```
 /*
@@ -39,7 +62,7 @@ const twigAdapter = require('@frctl/twig')({
     // this will change your includes to {% include '%button' %}
     // default is '@'
     handlePrefix: '%',
-    
+
     // set a base path for twigjs
     // Setting base to '/' will make sure all resolved render paths
     // start at the defined components dir, instead of being relative.

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -65,7 +65,7 @@ class TwigAdapter extends Fractal.Adapter {
                         let prefixMatcher = new RegExp(`^\\${self._config.handlePrefix}`);
                         let entity = source.find(handle.replace(prefixMatcher, '@'));
                         if (entity) {
-                            entity = entity.isVariant ? entity : entity.variants().default();
+                            entity = entity.isComponent ? entity.variants().default() : entity;
                             if (config.importContext) {
                                 context = utils.defaultsDeep(_.cloneDeep(context), entity.getContext());
                                 context._self = entity.toJSON();


### PR DESCRIPTION
This PR will:
- fix the usage for docs (the logic is now more similar to what happens in `@frctl/handlebars`)
- add documentaton for how to use this adapter properly for docs
- resolve #19 

Background for the documentation weirdness:
If the engines are set in the opposite order (for components first, then for docs), then due to the fact how the adapter currently extends & monkeypatches Twig, all includes will try to reference docs entities instead of component entities.

I think we should try to find a way to improve that, since the order of setting engines in the config should not make a difference.

Manually tested that, when following the docs:
- including components via handles still works
- including components via full path (with the usage of `base` config option, i don't believe regular relative paths have ever worked)
- `render` tag will continue to work