### PR TITLE
Allow usage of default twig.js template resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ const twigAdapter = require('@frctl/twig')({
     // default is false
     strict_variables: true,
 
+    // use twig.js default template loader
+    // this will allow including templates via relative paths, like twig.js or PHP Twig does by default
+    // changing this will break including components via their fractal handles
+    // changing this will break the custom render tag
+    // default is 'fractal'
+    method: 'fs',
+
     // register custom filters
     filters: {
         // usage: {{ label|capitalize }}

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -143,14 +143,14 @@ class TwigAdapter extends Fractal.Adapter {
 
         return new Promise(function(resolve, reject){
 
-            let tplPath = Path.relative(self._source.fullPath, path);
+            let tplPath = Path.relative(self._config.base || self._source.fullPath, path);
 
             try {
                 let template = self.engine.twig({
-                    method: 'fractal',
+                    method: self._config.method,
                     async: false,
                     rethrow: true,
-                    name: meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath,
+                    name: tplPath,
                     precompiled: str,
                     base: self._config.base,
                     strict_variables: self._config.strict_variables
@@ -174,6 +174,7 @@ class TwigAdapter extends Fractal.Adapter {
 module.exports = function(config) {
 
     config = _.defaults(config || {}, {
+        method: 'fractal',
         pristine: false,
         handlePrefix: '@',
         importContext: false,

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -143,14 +143,15 @@ class TwigAdapter extends Fractal.Adapter {
 
         return new Promise(function(resolve, reject){
 
-            let tplPath = Path.relative(self._config.base || self._source.fullPath, path);
+            let tplPath = Path.relative(self._source.fullPath, path);
 
             try {
                 let template = self.engine.twig({
                     method: self._config.method,
                     async: false,
                     rethrow: true,
-                    name: tplPath,
+                    name: self._config.method === 'fractal' ? (meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath) : undefined,
+                    path: path,
                     precompiled: str,
                     base: self._config.base,
                     strict_variables: self._config.strict_variables


### PR DESCRIPTION
This will:
- allow overriding twig.js template loader method in order to provide compatibility with twig.js (and PHP Twig) default behavior
- fix #42 

Changing the template loading method does, unfortunately, break the fractal-specific functionality that the adapter provides, but it's clearly documented and you have to opt out of the fractal loader, so i think it should be fine.