### PR TITLE
set source engine value

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -14,6 +14,8 @@ class TwigAdapter extends Fractal.Adapter {
         this._app = app;
         this._config = config;
 
+        source.set('engine', '@frctl/twig');
+
         let self = this;
 
         Twig.extend(function(Twig) {


### PR DESCRIPTION
Resolves #6.

Tested that:
- when setting the adapter as components engine, `_config.components.engine` value changes
- when setting the adapter as docs engine, `_config.docs.engine` value changes